### PR TITLE
Implemented context menu separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ SVG format is recommended for best cross-platform support.
 - [ ] Add highlight property
 - [ ] Add support for keyboard shortcuts
 - [ ] Improve accessibility features
-- [ ] Add support for submenus and separators
+- [ ] Add support for submenus
+- [x] Add support for separators
 - [ ] Add font icon support
 - [x] Add comprehensive unit and UI tests
 

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {
         "MSBuild.Sdk.Extras": "3.0.44",
         "Microsoft.Build.NoTargets" : "3.7.56"
-    }
+    } 
 }

--- a/sample/APES.MAUI.Sample.csproj
+++ b/sample/APES.MAUI.Sample.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-    <TargetFrameworks>net9.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false and $([MSBuild]::IsOSPlatform('windows')) == false">$(TargetFrameworks);net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false and $([MSBuild]::IsOSPlatform('windows')) == false">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 	<OutputType>Exe</OutputType>
 	<RootNamespace>APES.MAUI.Sample</RootNamespace>
 	<UseMaui>true</UseMaui>
@@ -37,7 +37,7 @@
 		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>
 		<DefineConstants>__WINDOWS__</DefineConstants>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(TargetFramework)' == 'Debug|net9.0-ios' ">
+	<PropertyGroup Condition=" '$(Configuration)|$(TargetFramework)' == 'Debug|net10.0-ios' ">
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>full</DebugType>
 		<Optimize>false</Optimize>

--- a/sample/MainPage.xaml
+++ b/sample/MainPage.xaml
@@ -76,6 +76,7 @@
             <c:ContextMenuContainer x:Name="container1" AutomationId="container1">
                 <c:ContextMenuContainer.MenuItems>
                     <c:ContextMenuItem x:Name="c1_action1" AutomationId="c1_action1" Text="Action 1" Command="{Binding FirstCommand}" CommandParameter="Action 1 pressed!" />
+                    <c:ContextMenuSeparator x:Name="c1_separator" />
                     <c:ContextMenuItem x:Name="c1_action2" AutomationId="c1_action2" Text="Action with icon" Command="{Binding FirstCommand}" CommandParameter="Action with icon pressed!" Icon="{Binding SettingsIconSource}"/>
                 </c:ContextMenuContainer.MenuItems>
                 <c:ContextMenuContainer.Content>

--- a/sample/run.sh
+++ b/sample/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TFM="net9.0-android"
+TFM="net10.0-android"
 CONFIG="Debug"
 PKG="com.apes.maui.sample"   # <-- change me
 LOG="maui-logcat.log"

--- a/src/APES.MAUI.csproj
+++ b/src/APES.MAUI.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false and $([MSBuild]::IsOSPlatform('windows')) == false">$(TargetFrameworks);net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false and $([MSBuild]::IsOSPlatform('windows')) == false">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'monoandroid13.0'">21.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'net9.0-android'">29.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'net10.0-android'">29.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>APES.MAUI</RootNamespace>
@@ -57,11 +57,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
 		<DefineConstants>$(DefineConstants);MAUI</DefineConstants>
 	  <UseMaui>true</UseMaui>
   </PropertyGroup>
-	<PropertyGroup Condition=" $(TargetFramework.StartsWith('net9.0-windows')) ">
+	<PropertyGroup Condition=" $(TargetFramework.StartsWith('net10.0-windows')) ">
 		<DefineConstants>$(DefineConstants);__WINDOWS__</DefineConstants>
 	</PropertyGroup>
   <ItemGroup>
@@ -73,7 +73,7 @@
     
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
     <PackageReference Include="Microsoft.Maui.Controls" />
   </ItemGroup>
   
@@ -86,18 +86,18 @@
     <Compile Include="Mac\*.cs" />
   </ItemGroup>
     
-    <ItemGroup Condition=" $(TargetFramework.StartsWith('net9.0-android')) ">
+    <ItemGroup Condition=" $(TargetFramework.StartsWith('net10.0-android')) ">
 	    <Compile Include="Droid\*.cs" />
     </ItemGroup>
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net9.0-ios')) or $(TargetFramework.StartsWith('net9.0-maccatalyst'))">
+    <ItemGroup Condition="$(TargetFramework.StartsWith('net10.0-ios')) or $(TargetFramework.StartsWith('net10.0-maccatalyst'))">
 	    <Compile Include="iOS\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition=" $(TargetFramework.StartsWith('net9.0-macos')) ">
+    <ItemGroup Condition=" $(TargetFramework.StartsWith('net10.0-macos')) ">
 	    <Compile Include="Mac\*.cs" />
     </ItemGroup>
 
-    <ItemGroup Condition=" $(TargetFramework.StartsWith('net9.0-windows')) ">
+    <ItemGroup Condition=" $(TargetFramework.StartsWith('net10.0-windows')) ">
 	    <Compile Include="UWP\*.cs" />
     </ItemGroup>
 

--- a/src/Droid/ContextMenuContainerRenderer.cs
+++ b/src/Droid/ContextMenuContainerRenderer.cs
@@ -244,6 +244,13 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
 
             _contextMenu = new PopupMenu(Context, child);
             _contextMenu.MenuItemClick += ContextMenu_MenuItemClick;
+            
+            // Enable group dividers for separators (API 28+)
+            if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.P)
+            {
+                _contextMenu.Menu.SetGroupDividerEnabled(true);
+            }
+    
             Field field = _contextMenu.Class.GetDeclaredField("mPopup");
             field.Accessible = true;
             Java.Lang.Object? menuPopupHelper = field.Get(_contextMenu);
@@ -275,10 +282,9 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
             switch (item)
             {
                 // Separator Items
-                case ContextMenuSeparator separatorItem:
+                case ContextMenuSeparator:
                 {
-                    // Android doesn't have native separators in context menus,
-                    // but we can create a disabled item with a separator character or empty text
+                    // For API < 28, create a disabled item as a visual separator
                     var separator = _contextMenu.Menu.Add("────────");
                     separator?.SetEnabled(false);
                     break;
@@ -339,9 +345,82 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
             // ReSharper disable once RedundantTypeCheckInPattern
             if (Element is ContextMenuContainer {MenuItems.Count: > 0} element)
             {
-                foreach (var item in element.MenuItems)
+                if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.P)
                 {
-                    AddMenuItem(item);
+                    // Use group-based separators for API 28+
+                    int currentGroupId = 0;
+            
+                    foreach (var item in element.MenuItems)
+                    {
+                        if (item is ContextMenuSeparator)
+                        {
+                            // Move to next group - this creates the visual separator
+                            currentGroupId++;
+                        }
+                        else if (item is ContextMenuItem contextItem)
+                        {
+                            AddMenuItemToGroup(contextItem, currentGroupId);
+                        }
+                    }
+                }
+                else
+                {
+                    // Fallback for API < 28
+                    foreach (var item in element.MenuItems)
+                    {
+                        AddMenuItem(item);
+                    }
+                }
+            }
+        }
+        
+        private void AddMenuItemToGroup(ContextMenuItem contextItem, int groupId)
+        {
+            if (_contextMenu is null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(contextItem.Text))
+            {
+                Logger.Error("ContextMenuItem text should not be empty!");
+                return;
+            }
+
+            var title = new SpannableString(contextItem.Text);
+            if (contextItem.IsDestructive)
+            {
+                title.SetSpan(new ForegroundColorSpan(AColor.Red), 0, title.Length(), 0);
+            }
+
+            // Add item to specific group
+            var contextAction = _contextMenu.Menu.Add(groupId, Menu.None, Menu.None, title);
+            if (contextAction is null)
+            {
+                Logger.Error("We couldn't create IMenuItem with title {0}", contextItem.Text);
+                return;
+            }
+
+            contextAction.SetEnabled(contextItem.IsEnabled);
+            if (contextItem.Icon != null && !string.IsNullOrWhiteSpace(contextItem.Icon.File))
+            {
+                string name = Path.GetFileNameWithoutExtension(contextItem.Icon.File);
+                int id = Context?.GetDrawableId(name) ?? 0;
+                if (id == 0)
+                {
+                    return;
+                }
+
+                var drawable = Context?.GetDrawable(id);
+                if (drawable is not null)
+                {
+                    var wrapper = new DrawableWrapperX(drawable, 0);
+                    if (contextItem.IsDestructive)
+                    {
+                        wrapper.SetTint(AColor.Red);
+                    }
+
+                    contextAction.SetIcon(wrapper);
                 }
             }
         }

--- a/src/Droid/ContextMenuContainerRenderer.cs
+++ b/src/Droid/ContextMenuContainerRenderer.cs
@@ -45,9 +45,9 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
         if (VirtualView is ContextMenuContainer newElement)
         {
             newElement.BindingContextChanged += Element_BindingContextChanged;
-            if (newElement.MenuItems != null)
+            if (newElement.MenuItems is not null)
             {
-                foreach (ContextMenuItem element in newElement.MenuItems)
+                foreach (var element in newElement.MenuItems)
                 {
                     element.PropertyChanged += Item_Changed;
                 }
@@ -62,15 +62,14 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
 
     protected override ContentViewGroup CreatePlatformView()
     {
-        if (VirtualView == null)
+        if (VirtualView is null)
         {
             throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a ContentViewGroup");
         }
 
         if (VirtualView is not ContextMenuContainer)
         {
-            throw new InvalidOperationException(
-                $"{nameof(VirtualView)} must be of type ContextMenuContainer, but was {VirtualView.GetType()} ");
+            throw new InvalidOperationException($"{nameof(VirtualView)} must be of type ContextMenuContainer, but was {VirtualView.GetType()} ");
         }
 
         var viewGroup = new ContainerViewGroup(Context);
@@ -88,27 +87,25 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
     private void MenuItems_CollectionChanged(
         object? sender,
         System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-
     {
-        if (e.OldItems != null)
+        if (e.OldItems is not null)
         {
-            foreach (ContextMenuItem element in e.OldItems)
+            foreach (BaseContextMenuItem item in e.OldItems)
             {
-                element.PropertyChanged -= Item_Changed;
+                item.PropertyChanged -= Item_Changed;
             }
         }
 
-        if (e.NewItems != null)
+        if (e.NewItems is not null)
         {
-            foreach (ContextMenuItem element in e.NewItems)
+            foreach (BaseContextMenuItem item in e.NewItems)
             {
-                element.PropertyChanged += Item_Changed;
+                item.PropertyChanged += Item_Changed;
             }
         }
 
         RefillMenuItems();
     }
-
 
     private void Item_Changed(object? sender, PropertyChangedEventArgs e) => ((ContainerViewGroup)PlatformView).NeedToRefillMenu = true;
 
@@ -219,7 +216,7 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
 
         private void DeconstructInteraction()
         {
-            if (Element != null && _contextMenu != null)
+            if (Element is not null && _contextMenu is not null)
             {
                 _contextMenu.Dismiss();
                 _contextMenu.Menu.Clear();
@@ -228,7 +225,7 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
 
         private void OpenContextMenu()
         {
-            if (GetContextMenu() == null)
+            if (GetContextMenu() is null)
             {
                 ConstructNativeMenu();
                 FillMenuItems();
@@ -240,7 +237,7 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
         private void ConstructNativeMenu()
         {
             var child = GetChildAt(0);
-            if (child == null)
+            if (child is null)
             {
                 return;
             }
@@ -257,7 +254,7 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
 
         private void DeconstructNativeMenu()
         {
-            if (_contextMenu == null)
+            if (_contextMenu is null)
             {
                 return;
             }
@@ -268,47 +265,71 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
             NeedToRefillMenu = false;
         }
 
-        private void AddMenuItem(ContextMenuItem item)
+        private void AddMenuItem(BaseContextMenuItem item)
         {
-            if (_contextMenu == null)
+            if (_contextMenu is null)
             {
                 return;
             }
 
-            var title = new SpannableString(item.Text);
-            if (item.IsDestructive)
+            switch (item)
             {
-                title.SetSpan(new ForegroundColorSpan(AColor.Red), 0, title.Length(), 0);
-            }
-
-            var contextAction = _contextMenu.Menu.Add(title);
-            if (contextAction == null)
-            {
-                Logger.Error("We couldn't create IMenuItem with title {0}", item.Text);
-                return;
-            }
-
-            contextAction.SetEnabled(item.IsEnabled);
-            
-
-            if (item.Icon != null)
-            {
-                string name = Path.GetFileNameWithoutExtension(item.Icon.File);
-                int id = Context?.GetDrawableId(name) ?? 0;
-                if (id == 0)
+                // Separator Items
+                case ContextMenuSeparator separatorItem:
                 {
-                    return;
+                    // Android doesn't have native separators in context menus,
+                    // but we can create a disabled item with a separator character or empty text
+                    var separator = _contextMenu.Menu.Add("────────");
+                    separator?.SetEnabled(false);
+                    break;
                 }
-                Drawable? drawable = Context?.GetDrawable(id);
-                if (drawable != null)
+
+                // Normal Items
+                case ContextMenuItem contextItem:
                 {
-                    var wrapper = new DrawableWrapperX(drawable,0);
-                    if (item.IsDestructive)
+                    if (string.IsNullOrEmpty(contextItem.Text))
                     {
-                        wrapper.SetTint(AColor.Red);
+                        Logger.Error("ContextMenuItem text should not be empty!");
+                        break;
                     }
 
-                    contextAction.SetIcon(wrapper);
+                    var title = new SpannableString(contextItem.Text);
+                    if (contextItem.IsDestructive)
+                    {
+                        title.SetSpan(new ForegroundColorSpan(AColor.Red), 0, title.Length(), 0);
+                    }
+
+                    var contextAction = _contextMenu.Menu.Add(title);
+                    if (contextAction is null)
+                    {
+                        Logger.Error("We couldn't create IMenuItem with title {0}", contextItem.Text);
+                        break;
+                    }
+
+                    contextAction.SetEnabled(contextItem.IsEnabled);
+                    if (contextItem.Icon != null && !string.IsNullOrWhiteSpace(contextItem.Icon.File))
+                    {
+                        string name = Path.GetFileNameWithoutExtension(contextItem.Icon.File);
+                        int id = Context?.GetDrawableId(name) ?? 0;
+                        if (id == 0)
+                        {
+                            break;
+                        }
+
+                        var drawable = Context?.GetDrawable(id);
+                        if (drawable is not null)
+                        {
+                            var wrapper = new DrawableWrapperX(drawable, 0);
+                            if (contextItem.IsDestructive)
+                            {
+                                wrapper.SetTint(AColor.Red);
+                            }
+
+                            contextAction.SetIcon(wrapper);
+                        }
+                    }
+
+                    break;
                 }
             }
         }
@@ -345,16 +366,16 @@ internal sealed class ContextMenuContainerRenderer : ContentViewHandler
         private void ContextMenu_MenuItemClick(object? sender, PopupMenu.MenuItemClickEventArgs e)
         {
             // ReSharper disable once RedundantCast
-            var item = ((ContextMenuContainer?)Element)?.MenuItems?.FirstOrDefault(
-                x => x.Text == e.Item.TitleFormatted?.ToString());
+            var item = ((ContextMenuContainer?)Element)?.MenuItems?
+                .Where(x => x is ContextMenuItem)
+                .Select(x => (ContextMenuItem)x)
+                .FirstOrDefault(x => x.Text == e.Item?.TitleFormatted?.ToString());
+
             item?.OnItemTapped();
         }
-        
+
         public bool NeedToRefillMenu { get; set; } = false;
-        
-
     }
-
 
     private class MyTimer
     {

--- a/src/Mac/ContextContainerNativeView.cs
+++ b/src/Mac/ContextContainerNativeView.cs
@@ -22,7 +22,7 @@ namespace APES.MAUI.Mac
             }
 
             _menuItems = contextMenuItems;
-            if (_menuItems != null)
+            if (_menuItems is not null)
             {
                 _menuItems.CollectionChanged += MenuItems_CollectionChanged;
             }
@@ -33,17 +33,14 @@ namespace APES.MAUI.Mac
         public override void RightMouseDown(NSEvent theEvent)
         {
             HandleContextActions(theEvent);
-
             base.RightMouseDown(theEvent);
         }
 
-        private void MenuItems_CollectionChanged(
-            object? sender,
-            System.Collections.Specialized.NotifyCollectionChangedEventArgs e) => RefillMenuItems();
+        private void MenuItems_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) => RefillMenuItems();
 
         private NSMenu? GetContextMenu()
         {
-            if (_contextMenu != null && _menuItems != null)
+            if (_contextMenu is not null && _menuItems is not null)
             {
                 if (_menuItems.Count != _contextMenu.Count)
                 {
@@ -68,7 +65,7 @@ namespace APES.MAUI.Mac
 
         private void HandleContextActions(NSEvent theEvent)
         {
-            if (_menuItems == null)
+            if (_menuItems is null)
             {
                 return;
             }
@@ -79,7 +76,7 @@ namespace APES.MAUI.Mac
                 return;
             }
 
-            if (GetContextMenu() == null)
+            if (GetContextMenu() is null)
             {
                 ConstructNativeMenu();
                 FillMenuItems();
@@ -105,7 +102,7 @@ namespace APES.MAUI.Mac
 
         private void RefillMenuItems()
         {
-            if (_contextMenu == null)
+            if (_contextMenu is null)
             {
                 return;
             }
@@ -116,34 +113,54 @@ namespace APES.MAUI.Mac
         }
 
 #pragma warning disable SA1202
-
         // ReSharper disable once InconsistentNaming
-        public NSMenuItem ToNSMenuItem(int i, ContextMenuItem menuItem)
+        public NSMenuItem ToNSMenuItem(int i, BaseContextMenuItem menuItem)
 #pragma warning restore SA1202
         {
-            NSMenuItem nsMenuItem = new NSMenuItem();
-            nsMenuItem.AttributedTitle = new NSAttributedString(
-                menuItem.Text,
-                foregroundColor: menuItem.IsDestructive ? NSColor.Red : null);
-            nsMenuItem.Tag = i;
-            nsMenuItem.Enabled = menuItem.IsEnabled;
-            nsMenuItem.Activated += NsMenuItem_Activated;
-            nsMenuItem.ValidateMenuItem = (t) => t.Enabled;
-            var nativeIcon = menuItem.Icon?.ToNative();
-            if (nativeIcon != null)
+            switch (menuItem)
             {
-                var elementColor = menuItem.IsDestructive ? NSColor.Red :
-                    NSAppearance.CurrentAppearance.Name == NSAppearance.NameDarkAqua ? NSColor.White : NSColor.Black;
-                nsMenuItem.Image = ImageHandler.ImageTintedWithColor(nativeIcon, elementColor, new CGSize(25, 25));
-            }
+                // Separator Items
+                case ContextMenuSeparator separatorItem:
+                {
+                    return NSMenuItem.SeparatorItem;
+                }
+                
+                // Normal Items
+                case ContextMenuItem contextItem:
+                {
+                    if (string.IsNullOrEmpty(contextItem.Text))
+                    {
+                        Logger.Error("ContextMenuItem text should not be empty!");
+                        return new NSMenuItem(); // Return empty item as fallback
+                    }
 
-            return nsMenuItem;
+                    NSMenuItem nsMenuItem = new NSMenuItem();
+                    nsMenuItem.AttributedTitle = new NSAttributedString(contextItem.Text, foregroundColor: contextItem.IsDestructive ? NSColor.Red : null);
+                    nsMenuItem.Tag = i;
+                    nsMenuItem.Enabled = contextItem.IsEnabled;
+                    nsMenuItem.Activated += NsMenuItem_Activated;
+                    nsMenuItem.ValidateMenuItem = (t) => t.Enabled;
+                    
+                    var nativeIcon = contextItem.Icon?.ToNative();
+                    if (nativeIcon is not null)
+                    {
+                        var elementColor = contextItem.IsDestructive
+                            ? NSColor.Red :
+                            NSAppearance.CurrentAppearance.Name == NSAppearance.NameDarkAqua ? NSColor.White : NSColor.Black;
+                        nsMenuItem.Image = ImageHandler.ImageTintedWithColor(nativeIcon, elementColor, new CGSize(25, 25));
+                    }
+
+                    return nsMenuItem;
+                }
+                
+                default:
+                    return new NSMenuItem();
+            }
         }
 
         private void NsMenuItem_Activated(object sender, EventArgs e)
         {
-            var nsMenuItem = sender as NSMenuItem;
-            if (nsMenuItem == null)
+            if (sender is not NSMenuItem nsMenuItem)
             {
                 Logger.Error("Couldn't cast sender to NSMenuItem");
                 return;

--- a/src/Mac/ContextMenuContainerRenderer.cs
+++ b/src/Mac/ContextMenuContainerRenderer.cs
@@ -17,7 +17,7 @@ namespace APES.MAUI.Mac
         protected override void OnElementChanged(ElementChangedEventArgs<ContextMenuContainer> e)
         {
             base.OnElementChanged(e);
-            if (e.NewElement == null || e.NewElement.Content == null)
+            if (e.NewElement is null || e.NewElement.Content is null)
             {
                 return;
             }

--- a/src/Shared/BaseContextMenuItem.cs
+++ b/src/Shared/BaseContextMenuItem.cs
@@ -1,0 +1,10 @@
+// MIT License
+// Copyright (c) 2021 Pavel Anpin
+
+using Microsoft.Maui.Controls;
+
+namespace APES.MAUI;
+
+public class BaseContextMenuItem : Element
+{
+}

--- a/src/Shared/ContextMenuContainer.cs
+++ b/src/Shared/ContextMenuContainer.cs
@@ -25,7 +25,7 @@ public class ContextMenuContainer : ContentView
     protected override void OnBindingContextChanged()
     {
         base.OnBindingContextChanged();
-        if (MenuItems != null)
+        if (MenuItems is not null)
         {
             SetBindingContextForItems(MenuItems);
         }
@@ -36,17 +36,17 @@ public class ContextMenuContainer : ContentView
         var menuItems = new ContextMenuItems();
         menuItems.CollectionChanged += (_, e) =>
         {
-            if (e.OldItems != null)
+            if (e.OldItems is not null)
             {
-                foreach (ContextMenuItem item in e.OldItems)
+                foreach (BindableObject item in e.OldItems)
                 {
                     item.RemoveBinding(BindingContextProperty);
                 }
             }
 
-            if (e.NewItems != null)
+            if (e.NewItems is not null)
             {
-                foreach (ContextMenuItem item in e.NewItems)
+                foreach (BindableObject item in e.NewItems)
                 {
                     SetInheritedBindingContext(item, bindableObject.BindingContext);
                 }
@@ -59,7 +59,7 @@ public class ContextMenuContainer : ContentView
     {
         if (oldValue is ContextMenuItems oldItems)
         {
-            foreach (ContextMenuItem item in oldItems)
+            foreach (var item in oldItems)
             {
                 item.RemoveBinding(BindingContextProperty);
             }
@@ -69,14 +69,14 @@ public class ContextMenuContainer : ContentView
 
         if (newValue is ContextMenuItems newItems)
         {
-            foreach (ContextMenuItem item in newItems)
+            foreach (var item in newItems)
             {
                 SetInheritedBindingContext(item, bindableObject.BindingContext);
             }
         }
     }
 
-    private void SetBindingContextForItems(IList<ContextMenuItem> items)
+    private void SetBindingContextForItems(IList<BaseContextMenuItem> items)
     {
         for (int i = 0; i < items.Count; i++)
         {
@@ -84,5 +84,5 @@ public class ContextMenuContainer : ContentView
         }
     }
 
-    private void SetBindingContextForItem(ContextMenuItem item) => SetInheritedBindingContext(item, BindingContext);
+    private void SetBindingContextForItem(BaseContextMenuItem item) => SetInheritedBindingContext(item, BindingContext);
 }

--- a/src/Shared/ContextMenuItem.cs
+++ b/src/Shared/ContextMenuItem.cs
@@ -2,14 +2,13 @@
 // Copyright (c) 2021 Pavel Anpin
 
 using System.Windows.Input;
-
 using Microsoft.Maui.Controls;
 
 namespace APES.MAUI;
 
 public delegate void ItemTapped(ContextMenuItem item);
 
-public class ContextMenuItem : Element
+public class ContextMenuItem : BaseContextMenuItem
 {
     public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(ContextMenuItem));
 

--- a/src/Shared/ContextMenuItems.cs
+++ b/src/Shared/ContextMenuItems.cs
@@ -6,23 +6,19 @@ using System.Collections.ObjectModel;
 
 namespace APES.MAUI
 {
-    public class ContextMenuItems : ObservableCollection<ContextMenuItem>
+    public class ContextMenuItems : ObservableCollection<BaseContextMenuItem>
     {
         public ContextMenuItem this[string text] => FindTextIndex(text);
 
         private ContextMenuItem FindTextIndex(string text)
         {
-            for (int j = 0; j < Items.Count; j++)
+            foreach (var item in Items)
             {
-                if (Items[j].Text == text)
-                {
-                    return Items[j];
-                }
+                if (item is ContextMenuItem contextMenuItem && contextMenuItem.Text == text)
+                    return contextMenuItem;
             }
 
-            throw new ArgumentOutOfRangeException(
-                nameof(text),
-                $"Item with  text {text} was not present");
+            throw new ArgumentOutOfRangeException(nameof(text), $"Item with text {text} was not present");
         }
     }
 }

--- a/src/Shared/ContextMenuSeparator.cs
+++ b/src/Shared/ContextMenuSeparator.cs
@@ -1,0 +1,8 @@
+// MIT License
+// Copyright (c) 2021 Pavel Anpin
+
+namespace APES.MAUI;
+
+public class ContextMenuSeparator : BaseContextMenuItem
+{
+}

--- a/src/UWP/ContextMenuContainerRenderer.cs
+++ b/src/UWP/ContextMenuContainerRenderer.cs
@@ -129,55 +129,78 @@ namespace APES.MAUI
             }
         }
 
-        private void AddMenuItem(MenuFlyout contextMenu, ContextMenuItem item)
+        private void AddMenuItem(MenuFlyout contextMenu, BaseContextMenuItem item)
         {
-            var nativeItem = new MenuFlyoutItem();
-            nativeItem.SetBinding(
-                MenuFlyoutItem.TextProperty,
-                new WBinding() { Path = new PropertyPath(nameof(ContextMenuItem.Text)) });
-
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            if (ImageConverter != null)
+            if (contextMenu.Items is null)
             {
-                nativeItem.SetBinding(
-                    MenuFlyoutItem.IconProperty,
-                    new WBinding() { Path = new PropertyPath(nameof(ContextMenuItem.Icon)), Converter = ImageConverter });
+                return;
             }
 
-            nativeItem.SetBinding(
-                FrameworkElement.StyleProperty,
-                new WBinding()
-                {
-                    Path = new PropertyPath(nameof(ContextMenuItem.IsDestructive)),
-                    Converter = BoolToStyleConverter,
-                });
-            nativeItem.SetBinding(
-                WControl.IsEnabledProperty,
-                new WBinding() { Path = new PropertyPath(nameof(ContextMenuItem.IsEnabled)) });
-            nativeItem.Click += NativeItem_Click;
-            nativeItem.DataContext = item;
-            if (contextMenu.Items != null)
+            switch (item)
             {
-                contextMenu.Items.Add(nativeItem);
+                // Separator Items
+                case ContextMenuSeparator separatorItem:
+                {
+                    var separator = new MenuFlyoutSeparator();
+                    contextMenu.Items.Add(separator);
+                    break;
+                }
+        
+                // Normal Items
+                case ContextMenuItem contextItem:
+                {
+                    if (string.IsNullOrEmpty(contextItem.Text))
+                    {
+                        Logger.Error("ContextMenuItem text should not be empty!");
+                        break;
+                    }
+
+                    var nativeItem = new MenuFlyoutItem();
+                    nativeItem.SetBinding(
+                        MenuFlyoutItem.TextProperty,
+                        new WBinding() { Path = new PropertyPath(nameof(ContextMenuItem.Text)) });
+
+                    // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+                    if (ImageConverter is not null)
+                    {
+                        nativeItem.SetBinding(
+                            MenuFlyoutItem.IconProperty,
+                            new WBinding() { Path = new PropertyPath(nameof(ContextMenuItem.Icon)), Converter = ImageConverter });
+                    }
+
+                    nativeItem.SetBinding(
+                        FrameworkElement.StyleProperty,
+                        new WBinding()
+                        {
+                            Path = new PropertyPath(nameof(ContextMenuItem.IsDestructive)),
+                            Converter = BoolToStyleConverter,
+                        });
+                    nativeItem.SetBinding(
+                        WControl.IsEnabledProperty,
+                        new WBinding() { Path = new PropertyPath(nameof(ContextMenuItem.IsEnabled)) });
+                    nativeItem.Click += NativeItem_Click;
+                    nativeItem.DataContext = contextItem;
+                    contextMenu.Items.Add(nativeItem);
+                    break;
+                }
             }
         }
 
         private void NativeItem_Click(object sender, RoutedEventArgs e)
         {
-            var item = sender as MenuFlyoutItem;
-            if (item == null)
+            if (sender is not MenuFlyoutItem item)
             {
-                Logger.Error("Couldn't cast to MenuFlyoutItem");
+                Logger.Error("Couldn't cast to MenuFlyoutItem.");
                 return;
             }
 
-            if (item.DataContext is not ContextMenuItem context)
+            if (item.DataContext is not ContextMenuItem contextItem)
             {
-                Logger.Error("Couldn't cast MenuFlyoutItem.DataContext to ContextMenuItem");
+                Logger.Error("Couldn't cast MenuFlyoutItem.DataContext to ContextMenuItem.");
                 return;
             }
 
-            context.OnItemTapped();
+            contextItem.OnItemTapped();
         }
 
 #pragma warning disable SA1201

--- a/src/iOS/ContextMenuContainerRenderer.cs
+++ b/src/iOS/ContextMenuContainerRenderer.cs
@@ -25,7 +25,7 @@ namespace APES.MAUI
                 if (VirtualView is ContextMenuContainer old)
                 {
                     old.BindingContextChanged -= Element_BindingContextChanged;
-                    if (old.MenuItems != null)
+                    if (old.MenuItems is not null)
                     {
                         old.MenuItems.CollectionChanged -= MenuItems_CollectionChanged;
                     }
@@ -37,7 +37,7 @@ namespace APES.MAUI
             if (VirtualView is ContextMenuContainer newElement)
             {
                 newElement.BindingContextChanged += Element_BindingContextChanged;
-                if (newElement.MenuItems != null)
+                if (newElement.MenuItems is not null)
                 {
                     newElement.MenuItems.CollectionChanged += MenuItems_CollectionChanged;
                 }
@@ -55,9 +55,7 @@ namespace APES.MAUI
             }
         }
 
-        private void MenuItems_CollectionChanged(
-            object? sender,
-            NotifyCollectionChangedEventArgs e) => RefillMenuItems();
+        private void MenuItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => RefillMenuItems();
 
         private void Element_BindingContextChanged(object? sender, EventArgs e) => RefillMenuItems();
 
@@ -69,7 +67,7 @@ namespace APES.MAUI
         private void DeconstructInteraction()
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            if (Control != null && _contextMenu != null)
+            if (Control is not null && _contextMenu is not null)
             {
                 Control.RemoveInteraction(_contextMenu);
             }
@@ -80,8 +78,7 @@ namespace APES.MAUI
             DeconstructInteraction();
             if (container.MenuItems?.Count > 0)
             {
-                _contextMenuDelegate =
-                    new ContextMenuDelegate(container.MenuItems, () => TraitCollection.UserInterfaceStyle);
+                _contextMenuDelegate = new ContextMenuDelegate(container.MenuItems, () => TraitCollection.UserInterfaceStyle);
                 _contextMenu = new UIContextMenuInteraction(_contextMenuDelegate);
                 Control.AddInteraction(_contextMenu);
             }

--- a/src/iOS/ContextMenuDelegate.cs
+++ b/src/iOS/ContextMenuDelegate.cs
@@ -39,37 +39,79 @@ internal class ContextMenuDelegate : UIContextMenuInteractionDelegate
     public override UIContextMenuConfiguration GetConfigurationForMenu(UIContextMenuInteraction interaction, CGPoint location)
         => UIContextMenuConfiguration.Create(_identifier, _preview != null ? PreviewDelegate! : null, ConstructMenuFromItems);
 
-    private IEnumerable<UIMenuElement> ToNativeActions(IEnumerable<ContextMenuItem> sharedDefinitions)
+    private IEnumerable<UIMenuElement> ToNativeActions(IEnumerable<BaseContextMenuItem> sharedDefinitions)
     {
         var iconColor = _getCurrentTheme() == UIUserInterfaceStyle.Dark ? UIColor.White : UIColor.Black;
-        foreach (var item in sharedDefinitions)
+        var items = sharedDefinitions.ToList();
+        var groups = new List<List<ContextMenuItem>>();
+        var currentGroup = new List<ContextMenuItem>();
+
+        // Group items by separators
+        foreach (var item in items)
         {
-            if (!string.IsNullOrEmpty(item.Text))
+            switch (item)
             {
-                UIImage? nativeImage = null;
-                if (item.Icon != null && !string.IsNullOrWhiteSpace(item.Icon.File))
-                {
-                    nativeImage = new UIImage(item.Icon.File);
-                    nativeImage = nativeImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
-                    nativeImage.ApplyTintColor(item.IsDestructive ? UIColor.Red : iconColor);
-                }
+                case ContextMenuSeparator:
+                    if (currentGroup.Count > 0)
+                    {
+                        groups.Add(currentGroup);
+                        currentGroup = new List<ContextMenuItem>();
+                    }
 
-                var nativeItem = UIAction.Create(item.Text, nativeImage, item.Text, ActionDelegate);
-                if (!item.IsEnabled)
-                {
-                    nativeItem.Attributes |= UIMenuElementAttributes.Disabled;
-                }
+                    break;
 
-                if (item.IsDestructive)
-                {
-                    nativeItem.Attributes |= UIMenuElementAttributes.Destructive;
-                }
-
-                yield return nativeItem;
+                case ContextMenuItem contextItem:
+                    currentGroup.Add(contextItem);
+                    break;
             }
-            else
+        }
+
+        // Add the last group if it has items
+        if (currentGroup.Count > 0)
+        {
+            groups.Add(currentGroup);
+        }
+
+        // Convert each group to a UIMenu with DisplayInline option
+        foreach (var group in groups)
+        {
+            var groupActions = new List<UIMenuElement>();
+
+            foreach (var contextItem in group)
             {
-                Logger.Error("ContextMenuItem text should not be empty!");
+                if (!string.IsNullOrEmpty(contextItem.Text))
+                {
+                    UIImage? nativeImage = null;
+                    if (contextItem.Icon is not null && !string.IsNullOrWhiteSpace(contextItem.Icon.File))
+                    {
+                        nativeImage = UIImage.FromBundle(contextItem.Icon.File);
+                        nativeImage = nativeImage?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+                        nativeImage?.ApplyTintColor(contextItem.IsDestructive ? UIColor.Red : iconColor);
+                    }
+
+                    var nativeItem = UIAction.Create(contextItem.Text, nativeImage, contextItem.Text, ActionDelegate);
+                    if (!contextItem.IsEnabled)
+                    {
+                        nativeItem.Attributes |= UIMenuElementAttributes.Disabled;
+                    }
+
+                    if (contextItem.IsDestructive)
+                    {
+                        nativeItem.Attributes |= UIMenuElementAttributes.Destructive;
+                    }
+
+                    groupActions.Add(nativeItem);
+                }
+                else
+                {
+                    Logger.Error("ContextMenuItem text should not be empty!");
+                }
+            }
+
+            if (groupActions.Count > 0)
+            {
+                yield return UIMenu.Create(string.Empty, null, UIMenuIdentifier.None, UIMenuOptions.DisplayInline,
+                    groupActions.ToArray());
             }
         }
     }
@@ -78,9 +120,10 @@ internal class ContextMenuDelegate : UIContextMenuInteractionDelegate
 
     private UIMenu ConstructMenuFromItems(UIMenuElement[] suggestedActions)
     {
-        _nativeMenu = _nativeMenu == null ?
+        _nativeMenu = _nativeMenu is null ?
             UIMenu.Create(ToNativeActions(_menuItems).ToArray()) :
             _nativeMenu.GetMenuByReplacingChildren(ToNativeActions(_menuItems).ToArray());
+
         return _nativeMenu;
     }
 

--- a/tests/ui/android/AppiumSetup.cs
+++ b/tests/ui/android/AppiumSetup.cs
@@ -23,7 +23,7 @@ public class AppiumSetup
             "sample", 
             "bin",
             "Release", 
-            "net9.0-android",
+            "net10.0-android",
             "publish",
             $"{AndroidApplication}-Signed.apk"));
     private static AppiumDriver? driver;

--- a/tests/ui/android/UITests.Android.csproj
+++ b/tests/ui/android/UITests.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net9.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/tests/ui/android/test.sh
+++ b/tests/ui/android/test.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-dotnet publish ../../../sample -f:net9.0-android -c Release \
+dotnet publish ../../../sample -f:net10.0-android -c Release \
     -p:RunAOTCompilation=true \
     -p:AndroidPackageFormat=apk
-adb install ../../../sample/bin/Release/net9.0-android/publish/com.apes.maui.sample-Signed.apk
+adb install ../../../sample/bin/Release/net10.0-android/publish/com.apes.maui.sample-Signed.apk
 dotnet test 

--- a/tests/ui/ios/AppiumSetup.cs
+++ b/tests/ui/ios/AppiumSetup.cs
@@ -21,7 +21,7 @@ public class AppiumSetup
             "sample", 
             "bin",
             "Release", 
-            "net9.0-ios",
+            "net10.0-ios",
             "iossimulator-x64",
             $"{iosApplication}.app"));
     private static AppiumDriver? driver;

--- a/tests/ui/ios/UITests.iOS.csproj
+++ b/tests/ui/ios/UITests.iOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net9.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/tests/ui/shared/UITests.Shared.csproj
+++ b/tests/ui/shared/UITests.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
 	<PropertyGroup>
-	  <TargetFramework>net9.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/ui/windows/AppiumSetup.cs
+++ b/tests/ui/windows/AppiumSetup.cs
@@ -26,7 +26,7 @@ public class AppiumSetup
             "sample", 
             "bin",
             "Release", 
-            "net9.0-windows10.0.19041.0", 
+            "net10.0-windows10.0.19041.0", 
 			"win-x64", 
 			"publish",
             $"{windowsApplication}.exe"));

--- a/tests/ui/windows/UITests.Windows.csproj
+++ b/tests/ui/windows/UITests.Windows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net9.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/tests/unit/unit.csproj
+++ b/tests/unit/unit.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>APES.MAUI.Tests</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
     <DefineConstants>$(DefineConstants);MAUI</DefineConstants>
   </PropertyGroup>
 
@@ -19,7 +19,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
     
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR adds context menu separators on all platforms.
- Added separators for Android, iOS, macOS, and Windows
- On Android SDK < 28, a button option appears with text content set to underline characters to simulate a separator
- Upgraded to .NET 10
- Added BaseContextMenuItem base for ContextMenuItem and ContextMenuSeparator which will make it easier to extend in the future
- Changed some `!= null` and `== null` to `is not null` and `is null`
- Changed `new UIImage(contextItem.Icon.File)` to `UIImage.FromBundle(contextItem.Icon.File)`
- Bumped iOS/MacCatalyst minimum version from 14.0 to 15.0
- Improved code formatting in some places

### iOS
<img width="402" height="430" alt="Screenshot 2026-02-16 at 22 24 40" src="https://github.com/user-attachments/assets/efa57df4-240b-4ee4-afab-e96f55bdfa90" />

### MacOS
<img width="402" height="430" alt="Screenshot 2026-02-16 at 22 26 02" src="https://github.com/user-attachments/assets/96312da6-6c6f-4245-8d78-88795bc1abef" />

### Android

**SDK >= 28**
<img width="336" height="381" alt="Screenshot 2026-02-16 at 22 46 05" src="https://github.com/user-attachments/assets/6fb3a108-a210-446c-809f-4ccba5fd5534" />

**SDK < 28**
<img width="352" height="430" alt="Screenshot 2026-02-16 at 22 21 29" src="https://github.com/user-attachments/assets/fc3c9d81-1d25-472b-b633-79906a4a13b9" />

### Windows
No screenshots. The code should be working anyway.